### PR TITLE
refactor: add vpc endpoint for SES

### DIFF
--- a/lib/network.ts
+++ b/lib/network.ts
@@ -59,6 +59,10 @@ export class NetworkStack extends Stack {
       }
     )
     sgForDecidimService.addIngressRule(sgForAlb, ec2.Port.tcp(80))
+    sgForDecidimService.addIngressRule(fromPeer, ec2.Port.tcp(465))
+    sgForDecidimService.addIngressRule(fromPeer, ec2.Port.tcp(587))
+    sgForDecidimService.addIngressRule(fromPeer, ec2.Port.tcp(2465))
+    sgForDecidimService.addIngressRule(fromPeer, ec2.Port.tcp(2587))
     this.sgForDecidimService = sgForDecidimService
 
     // SG for Rds
@@ -96,6 +100,20 @@ export class NetworkStack extends Stack {
     )
     sgForCache.addIngressRule(sgForDecidimService, ec2.Port.tcp(6379))
     this.sgForCache = sgForCache
+
+    // VPC Endpoint for SES
+    new ec2.InterfaceVpcEndpoint(
+      this,
+      `${ props.stage }VpcEndpointForSES`,
+      {
+        vpc,
+        service: ec2.InterfaceVpcEndpointAwsService.SES,
+        securityGroups: [sgForDecidimService],
+        subnets: {
+          subnetType: ec2.SubnetType.PUBLIC
+        }
+      }
+    )
   }
 
   /**

--- a/test/__snapshots__/network.test.ts.snap
+++ b/test/__snapshots__/network.test.ts.snap
@@ -697,6 +697,62 @@ exports[`NetworkStack Created 1`] = `
             "IpProtocol": "-1",
           },
         ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "from 0.0.0.0/0:465",
+            "FromPort": 465,
+            "IpProtocol": "tcp",
+            "ToPort": 465,
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "from 0.0.0.0/0:587",
+            "FromPort": 587,
+            "IpProtocol": "tcp",
+            "ToPort": 587,
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "from 0.0.0.0/0:2465",
+            "FromPort": 2465,
+            "IpProtocol": "tcp",
+            "ToPort": 2465,
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "from 0.0.0.0/0:2587",
+            "FromPort": 2587,
+            "IpProtocol": "tcp",
+            "ToPort": 2587,
+          },
+          {
+            "CidrIp": {
+              "Fn::GetAtt": [
+                "Vpc8378EB38",
+                "CidrBlock",
+              ],
+            },
+            "Description": {
+              "Fn::Join": [
+                "",
+                [
+                  "from ",
+                  {
+                    "Fn::GetAtt": [
+                      "Vpc8378EB38",
+                      "CidrBlock",
+                    ],
+                  },
+                  ":443",
+                ],
+              ],
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
         "VpcId": {
           "Ref": "Vpc8378EB38",
         },
@@ -799,6 +855,36 @@ exports[`NetworkStack Created 1`] = `
         "ToPort": 5432,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "stagingVpcEndpointForSES46F622C4": {
+      "Properties": {
+        "PrivateDnsEnabled": true,
+        "SecurityGroupIds": [
+          {
+            "Fn::GetAtt": [
+              "stagingSecurityGroupForDecidimService688CA6B9",
+              "GroupId",
+            ],
+          },
+        ],
+        "ServiceName": "com.amazonaws.ap-northeast-1.email-smtp",
+        "SubnetIds": [
+          {
+            "Ref": "VpcpublicSubnet1Subnet2BB74ED7",
+          },
+          {
+            "Ref": "VpcpublicSubnet2SubnetE34B022A",
+          },
+          {
+            "Ref": "VpcpublicSubnet3SubnetDFEF064A",
+          },
+        ],
+        "VpcEndpointType": "Interface",
+        "VpcId": {
+          "Ref": "Vpc8378EB38",
+        },
+      },
+      "Type": "AWS::EC2::VPCEndpoint",
     },
   },
   "Rules": {


### PR DESCRIPTION
#### :tophat: What? Why?
- vpc endpointの追加
- ses用のsgのポートの追加


#### :pushpin: Related Issues
- Fixes #31 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
