### PR TITLE
ALBのヘルスチェック用HTTPステータスコードで302を受け入れるように変更

### DIFF
--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -330,7 +330,7 @@ export class DecidimStack extends cdk.Stack {
         port: '80',
         path: '/',
         protocol: elbv2.Protocol.HTTP,
-        healthyHttpCodes: '301',
+        healthyHttpCodes: '301,302',
       },
       targets: [ecsService],
       targetGroupName: `${ props.stage }-${ props.serviceName }-TargetGroup`,

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -1080,7 +1080,7 @@ exports[`DecidimStack Created 1`] = `
         "HealthCheckPort": "80",
         "HealthCheckProtocol": "HTTP",
         "Matcher": {
-          "HttpCode": "301",
+          "HttpCode": "301,302",
         },
         "Name": "staging-decidim-TargetGroup",
         "Port": 80,


### PR DESCRIPTION
#### :tophat: What? Why?
- スタックをデプロイしようととしたところ、ALBからのヘルスチェックに失敗しました。
  - Decidimがホスト名が違っていた場合のリダイレクトに `302 Found` を利用していることが原因のようでした。
- テスト用のスナップショットの該当箇所に `302` を追記しました。


#### :pushpin: Related Issues
- Fixes #42 

#### :clipboard: Subtasks
- [ ] ヘルスチェックのHTTPステータスコードに302を追加しました。

### :camera: Screenshots (optional)
修正してデプロイに成功しているスクリーンショットです。

<img width="300" src="https://github.com/codeforjapan/decidim-cfj-cdk/assets/561613/1778cc7f-495a-4f68-8a4f-a6ca395f8ecb">

