### PR TITLE
READMEにドメインの許可を追記する方法を記載

### DIFF
--- a/docs/build_dev.md
+++ b/docs/build_dev.md
@@ -53,7 +53,7 @@ AWS Systems Manager のパラメータストアで以下のようなパラメー
 手元の環境で、[decidim-cfj](https://github.com/codeforjapan/decidim-cfj)のdocker imageをbuildする。
 デフォルトのままだと接続されるドメインを拒否してしまうため、Decidim の [config/environments/development.rb](https://github.com/codeforjapan/decidim-cfj/blob/main/config/environments/development.rb) に該当のドメイン（ホスト名）、もしくは全てのホスト名をconfigに追記する。
 
-<detaills>
+<details>
 <summary>追記例</summary>
 
 #### `something_your_domain.example.com` を許可する場合

--- a/docs/build_dev.md
+++ b/docs/build_dev.md
@@ -50,8 +50,6 @@ AWS Systems Manager のパラメータストアで以下のようなパラメー
 [プライベートリポジトリを作成する](https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/repository-create.html) を参考に AWS ECRのリポジトリを用意する。
 
 # 4-2 用意したリポジトリにdecidim の docker imageをpushする
-手元の環境で、[decidim-cfj](https://github.com/codeforjapan/decidim-cfj)のdocker imageをbuildする。
-
 デフォルトのままだと接続されるドメインを拒否してしまうため、Decidim の [config/environments/development.rb](https://github.com/codeforjapan/decidim-cfj/blob/main/config/environments/development.rb) に該当のドメイン（ホスト名）、もしくは全てのホスト名をconfigに追記する。
 
 <details>
@@ -83,6 +81,8 @@ To allow requests to local.example.com make sure it is a valid hostname (contain
 ![image (8)](https://github.com/codeforjapan/decidim-cfj-cdk/assets/561613/658fce09-8d1f-49d1-b9e7-48ab5b15f13d)
 
 </details>
+
+手元の環境で、[decidim-cfj](https://github.com/codeforjapan/decidim-cfj)のdocker imageをbuildする。
 
 [Docker イメージをプッシュする](https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/docker-push-ecr-image.html)を参考にbuildしたdocker imageを用意したリポジトリにpushする。
 

--- a/docs/build_dev.md
+++ b/docs/build_dev.md
@@ -50,7 +50,38 @@ AWS Systems Manager のパラメータストアで以下のようなパラメー
 [プライベートリポジトリを作成する](https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/repository-create.html) を参考に AWS ECRのリポジトリを用意する。
 
 # 4-2 用意したリポジトリにdecidim の docker imageをpushする
-手元の環境で、[decidim-cfj](https://github.com/codeforjapan/decidim-cfj)のdocker imageをbuildし、
+手元の環境で、[decidim-cfj](https://github.com/codeforjapan/decidim-cfj)のdocker imageをbuildする。
+デフォルトのままだと接続されるドメインを拒否してしまうため、Decidim の [config/environments/development.rb](https://github.com/codeforjapan/decidim-cfj/blob/main/config/environments/development.rb) に該当のドメイン（ホスト名）、もしくは全てのホスト名をconfigに追記する。
+
+<detaills>
+<summary>追記例</summary>
+
+#### `something_your_domain.example.com` を許可する場合
+
+```
+  config.hosts << "something_your_domain.example.com"
+  # No precompilation on demand on first request
+end
+```
+
+#### 全てのホスト名を許可する場合
+
+```
+  config.hosts.clear
+  # No precompilation on demand on first request
+end
+```
+
+#### この問題で発生するエラー例
+
+```
+Blocked host: something_your_domain.example.com
+To allow requests to local.example.com make sure it is a valid hostname (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:
+```
+
+![image (8)](https://github.com/codeforjapan/decidim-cfj-cdk/assets/561613/658fce09-8d1f-49d1-b9e7-48ab5b15f13d)
+
+</details>
 [Docker イメージをプッシュする](https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/docker-push-ecr-image.html)を参考に
 buildしたdocker imageを用意したリポジトリにpushする。
 

--- a/docs/build_dev.md
+++ b/docs/build_dev.md
@@ -51,6 +51,7 @@ AWS Systems Manager のパラメータストアで以下のようなパラメー
 
 # 4-2 用意したリポジトリにdecidim の docker imageをpushする
 手元の環境で、[decidim-cfj](https://github.com/codeforjapan/decidim-cfj)のdocker imageをbuildする。
+
 デフォルトのままだと接続されるドメインを拒否してしまうため、Decidim の [config/environments/development.rb](https://github.com/codeforjapan/decidim-cfj/blob/main/config/environments/development.rb) に該当のドメイン（ホスト名）、もしくは全てのホスト名をconfigに追記する。
 
 <details>
@@ -82,8 +83,8 @@ To allow requests to local.example.com make sure it is a valid hostname (contain
 ![image (8)](https://github.com/codeforjapan/decidim-cfj-cdk/assets/561613/658fce09-8d1f-49d1-b9e7-48ab5b15f13d)
 
 </details>
-[Docker イメージをプッシュする](https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/docker-push-ecr-image.html)を参考に
-buildしたdocker imageを用意したリポジトリにpushする。
+
+[Docker イメージをプッシュする](https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/docker-push-ecr-image.html)を参考にbuildしたdocker imageを用意したリポジトリにpushする。
 
 # 4-3 tagをexportする
 4-2でpushしたdockerイメージのタグをexportする


### PR DESCRIPTION
#### :tophat: What? Why?
- 現在のREADMEを元にデプロイしたところ、デプロイ後にブロックされました。
- 当初Decidim（とRoR）に詳しくなかったのでエラーの内容がAWS側で出しているものか区別ができず、READMEに記載されていると良いかと思いました。

#### :pushpin: Related Issues
- Fixes #44

#### :clipboard: Subtasks
- development.rb へのホスト名追記方法を記載
- 実際の記載方法は省略形で展開時のみ表示されるようにして記載しています。

### :camera: Screenshots (optional)
[こちらで確認可能](https://github.com/yousan/decidim-cfj-cdk/blob/feat/44-fix-readme-for-confighosts/docs/build_dev.md#4-2-%E7%94%A8%E6%84%8F%E3%81%97%E3%81%9F%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%ABdecidim-%E3%81%AE-docker-image%E3%82%92push%E3%81%99%E3%82%8B) です。

<img width="400" alt="image" src="https://github.com/codeforjapan/decidim-cfj-cdk/assets/561613/7789a41a-4f53-4336-abc5-55ccda88d23e">

