### PR TITLE
DecidimServiceがdevelopmentのDB接続情報で参照する環境変数を読み込ませるようにする

### DIFF
--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -119,6 +119,11 @@ export class DecidimStack extends cdk.Stack {
       RDS_HOSTNAME: props.rds,
       RDS_USERNAME: ssm.StringParameter.valueForTypedStringParameterV2(this, `/decidim-cfj/${ props.stage }/RDS_USERNAME`),
       RDS_PASSWORD: ssm.StringParameter.valueForTypedStringParameterV2(this, `/decidim-cfj/${ props.stage }/RDS_PASSWORD`),
+      // 以下は decidim リポジトリにあるdatabase.yaml の default で取得されている環境変数名。
+      DATABASE_HOST: props.rds,
+      // DATABASE_PORT: '5432',
+      DATABASE_USERNAME: ssm.StringParameter.valueForTypedStringParameterV2(this, `/decidim-cfj/${ props.stage }/RDS_USERNAME`),
+      DATABASE_PASSWORD: ssm.StringParameter.valueForTypedStringParameterV2(this, `/decidim-cfj/${ props.stage }/RDS_PASSWORD`),
       SECRET_KEY_BASE: ssm.StringParameter.valueForTypedStringParameterV2(this, `/decidim-cfj/${ props.stage }/SECRET_KEY_BASE`),
       SMTP_ADDRESS: ssm.StringParameter.valueForTypedStringParameterV2(this, `/decidim-cfj/${ props.stage }/SMTP_ADDRESS`),
       SMTP_USERNAME: ssm.StringParameter.valueForTypedStringParameterV2(this, `/decidim-cfj/${ props.stage }/SMTP_USERNAME`),

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -1200,6 +1200,24 @@ exports[`DecidimStack Created 1`] = `
                 },
               },
               {
+                "Name": "DATABASE_HOST",
+                "Value": {
+                  "Fn::ImportValue": "stagingdecidimRdsStack:ExportsOutputFnGetAttcreateRds829C4ED0EndpointAddressA146A595",
+                },
+              },
+              {
+                "Name": "DATABASE_USERNAME",
+                "Value": {
+                  "Ref": "SsmParameterValuedecidimcfjstagingRDSUSERNAMEC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+              },
+              {
+                "Name": "DATABASE_PASSWORD",
+                "Value": {
+                  "Ref": "SsmParameterValuedecidimcfjstagingRDSPASSWORDC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+              },
+              {
                 "Name": "SECRET_KEY_BASE",
                 "Value": {
                   "Ref": "SsmParameterValuedecidimcfjstagingSECRETKEYBASEC96584B6F00A464EAD1953AFF4B05118Parameter",
@@ -1392,6 +1410,24 @@ exports[`DecidimStack Created 1`] = `
               },
               {
                 "Name": "RDS_PASSWORD",
+                "Value": {
+                  "Ref": "SsmParameterValuedecidimcfjstagingRDSPASSWORDC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+              },
+              {
+                "Name": "DATABASE_HOST",
+                "Value": {
+                  "Fn::ImportValue": "stagingdecidimRdsStack:ExportsOutputFnGetAttcreateRds829C4ED0EndpointAddressA146A595",
+                },
+              },
+              {
+                "Name": "DATABASE_USERNAME",
+                "Value": {
+                  "Ref": "SsmParameterValuedecidimcfjstagingRDSUSERNAMEC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+              },
+              {
+                "Name": "DATABASE_PASSWORD",
                 "Value": {
                   "Ref": "SsmParameterValuedecidimcfjstagingRDSPASSWORDC96584B6F00A464EAD1953AFF4B05118Parameter",
                 },
@@ -1952,6 +1988,24 @@ exports[`DecidimStack Created 1`] = `
               },
               {
                 "Name": "RDS_PASSWORD",
+                "Value": {
+                  "Ref": "SsmParameterValuedecidimcfjstagingRDSPASSWORDC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+              },
+              {
+                "Name": "DATABASE_HOST",
+                "Value": {
+                  "Fn::ImportValue": "stagingdecidimRdsStack:ExportsOutputFnGetAttcreateRds829C4ED0EndpointAddressA146A595",
+                },
+              },
+              {
+                "Name": "DATABASE_USERNAME",
+                "Value": {
+                  "Ref": "SsmParameterValuedecidimcfjstagingRDSUSERNAMEC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+              },
+              {
+                "Name": "DATABASE_PASSWORD",
                 "Value": {
                   "Ref": "SsmParameterValuedecidimcfjstagingRDSPASSWORDC96584B6F00A464EAD1953AFF4B05118Parameter",
                 },


### PR DESCRIPTION
#### :tophat: What? Why?
- development用の環境変数を読み込ませるようにしました。

#### :pushpin: Related Issues
- Fixes #46 

### :camera: Screenshots (optional)
接続に成功したログです。

<img width="400" alt="image" src="https://github.com/codeforjapan/decidim-cfj-cdk/assets/561613/25073379-92c7-46ca-b84f-fd6de56b99b6">

### その他
本来は 

```
if (production){
 // RDS_系のロード
}else{  // at development
 // DATABASE_ 系のロード
}
```

にできると良かったのですが、書き方がわかりませんでした 🙇‍♂️ 