### PR TITLE
nginxのbufferサイズを大きく設定

### DIFF
--- a/lib/nginx/conf.d/default.conf
+++ b/lib/nginx/conf.d/default.conf
@@ -27,5 +27,7 @@ server {
         proxy_set_header    Host                   $host;
         proxy_set_header    X-Real-IP              $remote_addr;
         proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+        proxy_buffers 8 16k;
+        proxy_buffer_size 32k;
     }
 }

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -888,7 +888,7 @@ exports[`DecidimStack Created 1`] = `
             [
               "docker://",
               {
-                "Fn::Sub": "887442827229.dkr.ecr.ap-northeast-1.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-887442827229-ap-northeast-1:e2cba63dec4fd4bda0e19c605519329ba1bd6cd67c5a4bad8719225ea4ac4ec9",
+                "Fn::Sub": "887442827229.dkr.ecr.ap-northeast-1.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-887442827229-ap-northeast-1:8998b36c7eaef123d6958012fcb8e21bd33c3cbd44a96af9682077d8a7c97d7c",
               },
             ],
           ],


### PR DESCRIPTION
#### :tophat: What? Why?
nginxのbufferサイズによりサーバーエラーが起きていると考えられるため


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
