### PR TITLE
feat: enable Container Insights v2 for ECS clusters

### DIFF
--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -72,7 +72,9 @@ export class DecidimStack extends cdk.Stack {
       vpc: props.vpc,
       clusterName: `${props.stage}DecidimCluster`,
       enableFargateCapacityProviders: true,
-      containerInsightsV2: ecs.ContainerInsights.ENABLED,
+      containerInsightsV2: props.stage.startsWith('prd')
+        ? ecs.ContainerInsights.ENABLED
+        : ecs.ContainerInsights.DISABLED,
     });
 
     const ECSExecPolicyStatement = new aws_iam.PolicyStatement({

--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -72,6 +72,7 @@ export class DecidimStack extends cdk.Stack {
       vpc: props.vpc,
       clusterName: `${props.stage}DecidimCluster`,
       enableFargateCapacityProviders: true,
+      containerInsightsV2: ecs.ContainerInsights.ENABLED,
     });
 
     const ECSExecPolicyStatement = new aws_iam.PolicyStatement({

--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -174,6 +174,7 @@ export class DecidimStack extends cdk.Stack {
       DECIDIM_CACHE_EXPIRATION_TIME: '60',
       WEB_CONCURRENCY: '4',
       MALLOC_ARENA_MAX: '2',
+      DECIDIM_THROTTLING_MAX_REQUESTS: '1000',
     };
 
     const decidimRepository = aws_ecr.Repository.fromRepositoryName(

--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -176,7 +176,6 @@ export class DecidimStack extends cdk.Stack {
       DECIDIM_CACHE_EXPIRATION_TIME: '60',
       WEB_CONCURRENCY: '4',
       MALLOC_ARENA_MAX: '2',
-      DECIDIM_THROTTLING_MAX_REQUESTS: '1000',
     };
 
     const decidimRepository = aws_ecr.Repository.fromRepositoryName(

--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -172,6 +172,8 @@ export class DecidimStack extends cdk.Stack {
       DECIDIM_ADMIN_PASSWORD_MIN_LENGTH: '8',
       DECIDIM_ENABLE_HTML_HEADER_SNIPPETS: 'true',
       DECIDIM_CACHE_EXPIRATION_TIME: '60',
+      WEB_CONCURRENCY: '4',
+      MALLOC_ARENA_MAX: '2',
     };
 
     const decidimRepository = aws_ecr.Repository.fromRepositoryName(

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -1421,10 +1421,6 @@ exports[`DecidimStack Created 1`] = `
                 "Name": "MALLOC_ARENA_MAX",
                 "Value": "2",
               },
-              {
-                "Name": "DECIDIM_THROTTLING_MAX_REQUESTS",
-                "Value": "1000",
-              },
             ],
             "Essential": true,
             "HealthCheck": {
@@ -1642,10 +1638,6 @@ exports[`DecidimStack Created 1`] = `
               {
                 "Name": "MALLOC_ARENA_MAX",
                 "Value": "2",
-              },
-              {
-                "Name": "DECIDIM_THROTTLING_MAX_REQUESTS",
-                "Value": "1000",
               },
               {
                 "Name": "NEW_RELIC_AGENT_ENABLED",
@@ -2100,10 +2092,6 @@ exports[`DecidimStack Created 1`] = `
               {
                 "Name": "MALLOC_ARENA_MAX",
                 "Value": "2",
-              },
-              {
-                "Name": "DECIDIM_THROTTLING_MAX_REQUESTS",
-                "Value": "1000",
               },
               {
                 "Name": "NEW_RELIC_AGENT_ENABLED",

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -1421,6 +1421,10 @@ exports[`DecidimStack Created 1`] = `
                 "Name": "MALLOC_ARENA_MAX",
                 "Value": "2",
               },
+              {
+                "Name": "DECIDIM_THROTTLING_MAX_REQUESTS",
+                "Value": "1000",
+              },
             ],
             "Essential": true,
             "HealthCheck": {
@@ -1638,6 +1642,10 @@ exports[`DecidimStack Created 1`] = `
               {
                 "Name": "MALLOC_ARENA_MAX",
                 "Value": "2",
+              },
+              {
+                "Name": "DECIDIM_THROTTLING_MAX_REQUESTS",
+                "Value": "1000",
               },
               {
                 "Name": "NEW_RELIC_AGENT_ENABLED",
@@ -2092,6 +2100,10 @@ exports[`DecidimStack Created 1`] = `
               {
                 "Name": "MALLOC_ARENA_MAX",
                 "Value": "2",
+              },
+              {
+                "Name": "DECIDIM_THROTTLING_MAX_REQUESTS",
+                "Value": "1000",
               },
               {
                 "Name": "NEW_RELIC_AGENT_ENABLED",

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -676,7 +676,7 @@ exports[`DecidimStack Created 1`] = `
         "ClusterSettings": [
           {
             "Name": "containerInsights",
-            "Value": "enabled",
+            "Value": "disabled",
           },
         ],
       },

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -674,10 +674,10 @@ exports[`DecidimStack Created 1`] = `
       "Properties": {
         "ClusterName": "stagingDecidimCluster",
         "ClusterSettings": [
-            {
-                "Name": "containerInsights",
-                "Value": "enabled",
-            }
+          {
+            "Name": "containerInsights",
+            "Value": "enabled",
+          },
         ],
       },
       "Type": "AWS::ECS::Cluster",
@@ -1413,6 +1413,14 @@ exports[`DecidimStack Created 1`] = `
                 "Name": "DECIDIM_CACHE_EXPIRATION_TIME",
                 "Value": "60",
               },
+              {
+                "Name": "WEB_CONCURRENCY",
+                "Value": "4",
+              },
+              {
+                "Name": "MALLOC_ARENA_MAX",
+                "Value": "2",
+              },
             ],
             "Essential": true,
             "HealthCheck": {
@@ -1622,6 +1630,14 @@ exports[`DecidimStack Created 1`] = `
               {
                 "Name": "DECIDIM_CACHE_EXPIRATION_TIME",
                 "Value": "60",
+              },
+              {
+                "Name": "WEB_CONCURRENCY",
+                "Value": "4",
+              },
+              {
+                "Name": "MALLOC_ARENA_MAX",
+                "Value": "2",
               },
               {
                 "Name": "NEW_RELIC_AGENT_ENABLED",
@@ -2068,6 +2084,14 @@ exports[`DecidimStack Created 1`] = `
               {
                 "Name": "DECIDIM_CACHE_EXPIRATION_TIME",
                 "Value": "60",
+              },
+              {
+                "Name": "WEB_CONCURRENCY",
+                "Value": "4",
+              },
+              {
+                "Name": "MALLOC_ARENA_MAX",
+                "Value": "2",
               },
               {
                 "Name": "NEW_RELIC_AGENT_ENABLED",

--- a/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
+++ b/test/__snapshots__/decidim-cfj-cdk.test.ts.snap
@@ -673,6 +673,12 @@ exports[`DecidimStack Created 1`] = `
     "DecidimCluster7E0E2A4C": {
       "Properties": {
         "ClusterName": "stagingDecidimCluster",
+        "ClusterSettings": [
+            {
+                "Name": "containerInsights",
+                "Value": "enabled",
+            }
+        ],
       },
       "Type": "AWS::ECS::Cluster",
     },


### PR DESCRIPTION
#### :tophat: What? Why?
負荷試験の結果を踏まえた3つの改善と、モニタリング強化を実施

2026年3月18日に実施した負荷試験で特定されたボトルネックと運用課題への対応。

### 変更内容

#### 1. `WEB_CONCURRENCY=4`（Pumaワーカー数 2→4）
  - **問題**: 1タスクあたり約13 req/s（2ワーカー×5スレッド=10並列）に留まっていた
  - **変更**: ワーカー数を4に増やし、2 vCPUをより有効活用（4ワーカー×5スレッド=20並列）
  - **期待効果**: タスク追加なしで1タスクあたりの処理能力が1.5〜2倍に向上
  - **前提**: decidim-cfj側のPR（[#794](https://github.com/codeforjapan/decidim-cfj/pull/794)）でPumaWorkerKillerのRAM上限を2048→3072 MBに引き上げ済み

  #### 2. `MALLOC_ARENA_MAX=2`（glibcメモリアリーナ制限）
  - **問題**: Rubyプロセス（glibc）はデフォルトでCPUコア数×8のメモリアリーナを作成し、メモリ断片化によるメモリ使用量の肥大化が発生する
  - **変更**: アリーナ数を2に制限し、ワーカー数増加に伴うメモリ消費増を抑制
  - **根拠**: Heroku/Sidekiq公式の推奨設定。ワーカー4つ×デフォルトアリーナだとメモリ断片化が加速し、PumaWorkerKillerによるkillが頻発するリスクがある

  #### 3. `DECIDIM_THROTTLING_MAX_REQUESTS=1000`（Rate Limit引き上げ）

  - **問題**: 第1回負荷試験でRack::Attack（デフォルト100 req/分/IP）が作動し、53.6%のリクエストが429エラーとなり、アプリ本体の限界を測定できなかった
  - **本番運用への影響**: ワークショップ会場のWi-Fi等、NAT配下で多数のユーザーが同一IPからアクセスする場合にデフォルト100 req/分の上限に到達する可能性がある
  - **変更**: 1000 req/分/IPに引き上げ。通常のブラウザ利用（1人4〜6 req/分）を考慮すると、同一IP下で約160〜250人が同時利用可能

  #### 4. Container Insights v2 有効化（本番のみ）
  - **問題**: 負荷試験中にECSクラスタのContainer Insightsが無効であることが判明した
  - **変更**: CDKでprd環境のみContainer Insights v2を有効化し、コード管理下に置く
  - **効果**: ECSタスクレベルのCPU・メモリ・ネットワークメトリクスをCloudWatchで収集可能に

  #### :pushpin: Related Issues
  - PumaWorkerKiller RAM上限引き上げ: [decidim-cfj#794](https://github.com/codeforjapan/decidim-cfj/pull/794)
#### :clipboard: Subtasks

- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

![Description](URL)
