### PR TITLE
feat: dev/stagingのBot Control削除とnoindexヘッダー追加

### DIFF
--- a/lib/cloudfront.ts
+++ b/lib/cloudfront.ts
@@ -349,9 +349,7 @@ export class CloudFrontStack extends Stack {
     const noIndexResponseHeadersPolicy = !isPrd
       ? new ResponseHeadersPolicy(this, 'NoIndexResponseHeadersPolicy', {
           customHeadersBehavior: {
-            customHeaders: [
-              { header: 'X-Robots-Tag', value: 'noindex, nofollow', override: true },
-            ],
+            customHeaders: [{ header: 'X-Robots-Tag', value: 'noindex, nofollow', override: true }],
           },
         })
       : undefined;

--- a/lib/cloudfront.ts
+++ b/lib/cloudfront.ts
@@ -15,6 +15,7 @@ import {
   AllowedMethods,
   CachePolicy,
   OriginRequestPolicy,
+  ResponseHeadersPolicy,
   ViewerProtocolPolicy,
 } from 'aws-cdk-lib/aws-cloudfront';
 import {
@@ -272,31 +273,6 @@ export class CloudFrontStack extends Stack {
           metricName: `production-AllowSystemLogin`,
         },
       });
-    } else {
-      rules.push({
-        name: `${props.stage}-${props.serviceName}-BlockAllBots`,
-        priority: 7,
-        statement: {
-          managedRuleGroupStatement: {
-            vendorName: 'AWS',
-            name: 'AWSManagedRulesBotControlRuleSet',
-            managedRuleGroupConfigs: [
-              {
-                awsManagedRulesBotControlRuleSet: {
-                  inspectionLevel: 'TARGETED',
-                  enableMachineLearning: true,
-                },
-              },
-            ],
-          },
-        },
-        overrideAction: { none: {} },
-        visibilityConfig: {
-          cloudWatchMetricsEnabled: true,
-          sampledRequestsEnabled: true,
-          metricName: `${props.stage}-${props.serviceName}-BlockAllBots`,
-        },
-      });
     }
 
     rules.push({
@@ -369,6 +345,17 @@ export class CloudFrontStack extends Stack {
 
     const isPrd = props.stage === 'prd-v0292';
 
+    // dev/staging は検索エンジンにインデックスさせない
+    const noIndexResponseHeadersPolicy = !isPrd
+      ? new ResponseHeadersPolicy(this, 'NoIndexResponseHeadersPolicy', {
+          customHeadersBehavior: {
+            customHeaders: [
+              { header: 'X-Robots-Tag', value: 'noindex, nofollow', override: true },
+            ],
+          },
+        })
+      : undefined;
+
     const stripS3PrefixFn = new cloudfront.Function(this, 'StripS3PrefixFn', {
       code: cloudfront.FunctionCode.fromInline(`
                 function handler(event) {
@@ -405,6 +392,7 @@ export class CloudFrontStack extends Stack {
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: CachePolicy.CACHING_DISABLED,
         originRequestPolicy: OriginRequestPolicy.ALL_VIEWER,
+        responseHeadersPolicy: noIndexResponseHeadersPolicy,
       },
       // Botによる無効URLへの連続アクセスがRailsまで到達するのを防ぐ。
       // 新規ページ追加時に一時的に404が返る可能性があるため、TTLは短く設定する。

--- a/test/__snapshots__/cloudfront.test.ts.snap
+++ b/test/__snapshots__/cloudfront.test.ts.snap
@@ -259,32 +259,6 @@ exports[`Cloudfront Stack Created 1`] = `
             },
           },
           {
-            "Name": "staging-decidim-BlockAllBots",
-            "OverrideAction": {
-              "None": {},
-            },
-            "Priority": 7,
-            "Statement": {
-              "ManagedRuleGroupStatement": {
-                "ManagedRuleGroupConfigs": [
-                  {
-                    "AWSManagedRulesBotControlRuleSet": {
-                      "EnableMachineLearning": true,
-                      "InspectionLevel": "TARGETED",
-                    },
-                  },
-                ],
-                "Name": "AWSManagedRulesBotControlRuleSet",
-                "VendorName": "AWS",
-              },
-            },
-            "VisibilityConfig": {
-              "CloudWatchMetricsEnabled": true,
-              "MetricName": "staging-decidim-BlockAllBots",
-              "SampledRequestsEnabled": true,
-            },
-          },
-          {
             "Action": {
               "Block": {
                 "CustomResponse": {
@@ -446,6 +420,9 @@ exports[`Cloudfront Stack Created 1`] = `
             "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
             "Compress": true,
             "OriginRequestPolicyId": "216adef6-5c7f-47e4-b989-5492eafa07d3",
+            "ResponseHeadersPolicyId": {
+              "Ref": "NoIndexResponseHeadersPolicy95873CF2",
+            },
             "TargetOriginId": "stagingdecidimCloudFrontStackDistributionOrigin1E886134A",
             "ViewerProtocolPolicy": "redirect-to-https",
           },
@@ -501,6 +478,23 @@ exports[`Cloudfront Stack Created 1`] = `
         },
       },
       "Type": "AWS::CloudFront::Distribution",
+    },
+    "NoIndexResponseHeadersPolicy95873CF2": {
+      "Properties": {
+        "ResponseHeadersPolicyConfig": {
+          "CustomHeadersConfig": {
+            "Items": [
+              {
+                "Header": "X-Robots-Tag",
+                "Override": true,
+                "Value": "noindex, nofollow",
+              },
+            ],
+          },
+          "Name": "stagingdecidimCloudFrontStackNoIndexResponseHeadersPolicy13E62266",
+        },
+      },
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
     },
     "StripS3PrefixFnC8BFE398": {
       "Properties": {


### PR DESCRIPTION
## Summary

- dev/staging の WAF から Targeted Bot Control を削除（$30/月 × 2環境 = **$60/月削減**）
- CloudFront Response Headers Policy で `X-Robots-Tag: noindex, nofollow` を dev/staging に追加

## 背景

- dev/staging は内部トラフィックのみで Bot Control の実効性がなく、WAF ログも無効のため検知結果も確認できない状態だった
- Bot Control 削除後に PR #828（robots.txt の `Disallow: /` 削除）がデプロイされると Googlebot が dev/staging を crawl できるようになるため、`X-Robots-Tag: noindex` で検索インデックスを防止する

## 影響範囲

- **本番（prd-v0292）への影響なし** — `isPrd` フラグで明確に分岐
- dev/staging の全レスポンスに `X-Robots-Tag: noindex, nofollow` が付与される

## Test plan

- [ ] `cdk diff --context stage=dev` で Bot Control ルール削除と ResponseHeadersPolicy 追加のみ確認
- [ ] dev デプロイ後、`curl -sI https://<dev-domain>/ | grep x-robots-tag` で `noindex, nofollow` が返ることを確認
- [ ] Google Search Console で dev/staging ドメインがインデックスされていないことを確認