### PR TITLE
feat: 本番stage prd-v030 を追加

### DIFF
--- a/bin/decidim-cfj-cdk.ts
+++ b/bin/decidim-cfj-cdk.ts
@@ -12,7 +12,7 @@ import { Tags } from 'aws-cdk-lib';
 
 const app = new cdk.App();
 
-const stages = ['dev', 'staging', 'prd-v0292'] as const;
+const stages = ['dev', 'staging', 'prd-v0292', 'prd-v030'] as const;
 const stage = app.node.tryGetContext('stage') as string;
 const tag = app.node.tryGetContext('tag') as string;
 if (!stages.includes(stage as (typeof stages)[number])) {

--- a/config/prd-v030.json
+++ b/config/prd-v030.json
@@ -1,0 +1,51 @@
+{
+  "rds": {
+    "snapshot": true,
+    "snapshotIdentifier": "decidim-master-2026-07-31",
+    "instanceType": "t4g.medium",
+    "deletionProtection": true,
+    "allocatedStorage": 20,
+    "maxAllocatedStorage": 40,
+    "enablePerformanceInsights": true,
+    "multiAz": true
+  },
+
+  "aws": {
+    "accountId": "887442827229",
+    "region": "ap-northeast-1"
+  },
+
+  "s3Bucket": "prd-v030-decidim",
+
+  "cacheNodeType": "cache.t3.medium",
+  "engineVersion": "6.x",
+  "numCacheNodes": 2,
+  "automaticFailoverEnabled": true,
+
+  "ecs": {
+    "smtpDomain": "diycities.jp",
+    "repository": "decidim-cfj",
+    "certificates": [
+      "arn:aws:acm:ap-northeast-1:887442827229:certificate/faa7a120-3843-4561-93ec-c3d313356ad5",
+      "arn:aws:acm:ap-northeast-1:887442827229:certificate/b02c7415-d6f8-4794-994e-fe5689ca7b74"
+    ],
+    "fargateSpotCapacityProvider": {
+      "weight": 1
+    },
+    "fargateCapacityProvider": {
+      "base": 1,
+      "weight": 2
+    },
+    "mainApp": {
+      "cpu": 2048,
+      "memory": 4096
+    },
+    "sidekiq": {
+      "cpu": 512,
+      "memory": 2048
+    }
+  },
+
+  "domain": "diycities.jp",
+  "cloudfrontCertificate": "arn:aws:acm:us-east-1:887442827229:certificate/8aec1d57-e068-47f3-a180-e0c1fbb782de"
+}

--- a/lib/cloudfront.ts
+++ b/lib/cloudfront.ts
@@ -222,7 +222,7 @@ export class CloudFrontStack extends Stack {
       },
     ];
 
-    if (props.stage === 'prd-v0292') {
+    if (props.stage === 'prd-v0292' || props.stage === 'prd-v030') {
       rules.push({
         name: 'production-AllowSystemLogin',
         priority: 7,
@@ -328,12 +328,15 @@ export class CloudFrontStack extends Stack {
     });
 
     // WAF Log（本番環境のみ）
-    if (props.stage === 'prd-v0292') {
+    if (props.stage === 'prd-v0292' || props.stage === 'prd-v030') {
+      // autoDeleteObjects は付けない。付けると CDK が AWS::S3::BucketPolicy を生成するが、
+      // 後続の WafLoggingConfig 作成時に AWS のログ配信サービスが AWSLogDeliveryWrite ポリシーを
+      // 同一バケットへ自動付与するため「bucket policy already exists」で CREATE_FAILED となる。
+      // WAF ログ用途はこの自動付与ポリシーのみで足りる。破棄時は手動で空にする運用とする。
       const wafLogBucket = new aws_s3.Bucket(this, `${props.stage}WafLogBucket`, {
         bucketName: `aws-waf-logs-${props.s3BucketName}`,
         blockPublicAccess: aws_s3.BlockPublicAccess.BLOCK_ALL,
         removalPolicy: RemovalPolicy.DESTROY,
-        autoDeleteObjects: true,
         lifecycleRules: [{ expiration: Duration.days(180) }],
       });
 
@@ -343,7 +346,12 @@ export class CloudFrontStack extends Stack {
       });
     }
 
-    const isPrd = props.stage === 'prd-v0292';
+    const isPrd = props.stage === 'prd-v0292' || props.stage === 'prd-v030';
+
+    // 初回デプロイ時など、既存ディストリビューションとの CNAME 衝突（CNAMEAlreadyExists）を
+    // 避けるため、`-c claimWildcard=false` でワイルドカード(*.domain)エイリアスの付与をスキップできる。
+    // 既定は true。切替後に associate-alias でワイルドカードを移動したら、フラグ無し（true）で再デプロイして整合させる。
+    const claimWildcard = this.node.tryGetContext('claimWildcard') !== 'false';
 
     // dev/staging は検索エンジンにインデックスさせない
     const noIndexResponseHeadersPolicy = !isPrd
@@ -401,7 +409,7 @@ export class CloudFrontStack extends Stack {
         },
       ],
       comment: `${props.stage}-${props.serviceName}-cloudfront`,
-      domainNames: isPrd ? [endpoint, `*.${props.domain}`] : [endpoint],
+      domainNames: isPrd && claimWildcard ? [endpoint, `*.${props.domain}`] : [endpoint],
       certificate: aws_certificatemanager.Certificate.fromCertificateArn(
         this,
         'cloudFrontCertificate',

--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -221,9 +221,9 @@ export class DecidimStack extends cdk.Stack {
       environment: {
         ...DecidimContainerEnvironment,
         ...{
-          NEW_RELIC_AGENT_ENABLED: props.stage === 'prd-v0292' ? 'true' : 'false',
+          NEW_RELIC_AGENT_ENABLED: props.stage === 'prd-v0292' || props.stage === 'prd-v030' ? 'true' : 'false',
           NEW_RELIC_LICENSE_KEY:
-            props.stage === 'prd-v0292'
+            props.stage === 'prd-v0292' || props.stage === 'prd-v030'
               ? ssm.StringParameter.valueForTypedStringParameterV2(
                   this,
                   `/decidim-cfj/${props.stage}/NEW_RELIC_LICENSE_KEY`

--- a/lib/decidim-stack.ts
+++ b/lib/decidim-stack.ts
@@ -221,7 +221,8 @@ export class DecidimStack extends cdk.Stack {
       environment: {
         ...DecidimContainerEnvironment,
         ...{
-          NEW_RELIC_AGENT_ENABLED: props.stage === 'prd-v0292' || props.stage === 'prd-v030' ? 'true' : 'false',
+          NEW_RELIC_AGENT_ENABLED:
+            props.stage === 'prd-v0292' || props.stage === 'prd-v030' ? 'true' : 'false',
           NEW_RELIC_LICENSE_KEY:
             props.stage === 'prd-v0292' || props.stage === 'prd-v030'
               ? ssm.StringParameter.valueForTypedStringParameterV2(

--- a/lib/elasticache-stack.ts
+++ b/lib/elasticache-stack.ts
@@ -40,7 +40,7 @@ export class ElasticacheStack extends Stack {
       cacheParameterGroupName: parameterGroup.ref,
     };
 
-    if (props.stage === 'prd-v0292') {
+    if (props.stage === 'prd-v0292' || props.stage === 'prd-v030') {
       this.redis = new elasticache.CfnReplicationGroup(this, 'prdElasticache', {
         ...elastiCacheProps,
         ...{

--- a/lib/rds-stack.ts
+++ b/lib/rds-stack.ts
@@ -86,7 +86,7 @@ export class RdsStack extends Stack {
     }
 
     // 本番のみRDS監視アラームを作成（DevOps Guru無効化の代替、Issue #95）
-    if (props.stage === 'prd-v0292') {
+    if (props.stage === 'prd-v0292' || props.stage === 'prd-v030') {
       this.addProductionAlarms(this.rds);
     }
   }

--- a/lib/s3-stack.ts
+++ b/lib/s3-stack.ts
@@ -13,7 +13,7 @@ export class S3Stack extends Stack {
 
     const bucket = new aws_s3.Bucket(this, 'createBucket', {
       bucketName: `${props.bucketName}-bucket`,
-      versioned: props.stage === 'prd-v0292',
+      versioned: props.stage === 'prd-v0292' || props.stage === 'prd-v030',
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
       blockPublicAccess: aws_s3.BlockPublicAccess.BLOCK_ALL,


### PR DESCRIPTION
## 概要

本番環境を `prd-v0292` から新 stage `prd-v030`（Decidim v0.30 / PostgreSQL 16.13）へブルーグリーン移行するための CDK 対応です。2026-07-31 に prd-v030 環境を構築し、`*.diycities.jp` を無停止で prd-v030 へ切替済みです。本 PR はその際に行ったコード変更を main に反映します（CI `_deploy.yaml` は本リポジトリの main から CDK をチェックアウトするため）。

## 変更点

- **stage 追加**: `bin/decidim-cfj-cdk.ts` の `stages` に `prd-v030` を追加。`config/prd-v030.json` を新規追加（prd-v0292 相当、`snapshotIdentifier=decidim-master-2026-07-31` / `s3Bucket=prd-v030-decidim`）。
- **本番向け条件分岐に prd-v030 を追加**: WAF ルール・WAF ログ・noindex（cloudfront）、NewRelic（decidim）、本番 Redis 構成（elasticache）、バケットバージョニング（s3）、本番 RDS 監視アラーム（rds）。
- **cloudfront.ts: WAF ログバケットの `autoDeleteObjects` を除去**
  WAF のログ配信サービスが `AWSLogDeliveryWrite` バケットポリシーを自動付与するため、`autoDeleteObjects` 由来の `AWS::S3::BucketPolicy` と競合し「The bucket policy already exists」で CREATE_FAILED になる。S3 のバケットポリシーは 1 個のみのため、AWS が自動管理するバケットに CDK 側でポリシーを持たせない方針とした。破棄時は手動で空にする（180 日ライフサイクル有り）。
- **cloudfront.ts: `claimWildcard` コンテキストフラグを追加**
  ブルーグリーン切替の初回デプロイで、既存ディストリビューションが保持する `*.diycities.jp` との CNAME 衝突（`CNAMEAlreadyExists`）を避けるため、`-c claimWildcard=false` でワイルドカード付与をスキップできる。既定は `true`（従来挙動）で無害。切替後は `update-domain-association` でエイリアスを移動し、既定で再デプロイして整合させる。

## テスト

- `npm run test`: 全スナップショット pass（既存スナップショットへの影響なし）
- `cdk synth -c stage=prd-v030`: 全 6 スタック合成成功
- 本番切替実施済み: `kakogawa.diycities.jp` 等の本番テナントが prd-v030 経由で HTTP 200 を確認
